### PR TITLE
Version parsing for upgrade decision

### DIFF
--- a/plexupdate.sh
+++ b/plexupdate.sh
@@ -16,7 +16,9 @@ newversion=$(echo $jq | jq -r .nas.Synology.version)
 echo New Ver: $newversion
 curversion=$(synopkg version "Plex Media Server")
 echo Cur Ver: $curversion
-if [ "$newversion" != "$curversion" ]
+newversionshort=$(echo ${newversion} | cut -d'-' -f1)
+curversionshort=$(echo ${curversion} | cut -d'-' -f1)
+if [ "$newversionshort" != "$curversionshort" ]
 then
 echo New Vers Available
 /usr/syno/bin/synonotify PKGHasUpgrade '{"[%HOSTNAME%]": $(hostname), "[%OSNAME%]": "Synology", "[%PKG_HAS_UPDATE%]": "Plex", "[%COMPANY_NAME%]": "Synology"}'


### PR DESCRIPTION
I slightly changed the IF block.
It is comparing full version names with different hashes for same version in the current state of the script.
For example:
```
New Ver: 1.22.2.4282-a97b03fad
Cur Ver: 1.22.2.4282-6000
```

I cut the suffix from the version, so only the part before the first dash is taken into the account in the IF. In the example above it would parse both new and current versions to `1.22.2.4282`
I'm only using the shorter versions to decide if upgrading is necessary, so you can still see the full version in logs.